### PR TITLE
Fixed bug with Addressfinder Widget configuration

### DIFF
--- a/view/frontend/templates/checkout.phtml
+++ b/view/frontend/templates/checkout.phtml
@@ -8,7 +8,7 @@
             var widgetConfig = {
                     key: "<?=$block->getLicenceKey()?>",
                 <?php if ($block->hasWidgetOptions()): ?>
-                    widgetOptions: "<?=$block->getWidgetOptionsEscaped()?>",
+                    options: "<?=$block->getWidgetOptionsEscaped()?>",
                 <?php endif ?>
                 <?php if ($block->isDebugMode()): ?>
                     debug: true,

--- a/view/frontend/templates/customer.phtml
+++ b/view/frontend/templates/customer.phtml
@@ -9,7 +9,7 @@
             var widgetConfig = {
                     key: "<?=$block->getLicenceKey()?>",
                 <?php if ($block->hasWidgetOptions()): ?>
-                    widgetOptions: "<?=$block->getWidgetOptionsEscaped()?>",
+                    options: "<?=$block->getWidgetOptionsEscaped()?>",
                 <?php endif ?>
                 <?php if ($block->isDebugMode()): ?>
                     debug: true,


### PR DESCRIPTION
Addressfinder Widget Options don't apply because widget is looking for 'options' key, while it's named 'widgetOptions' in template which declares it