### PR TITLE
Add support for the conditional availabilty of states within Australia

### DIFF
--- a/Exception/NoStateMappingsException.php
+++ b/Exception/NoStateMappingsException.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AddressFinder\AddressFinder\Exception;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Phrase;
+
+class NoStateMappingsException extends LocalizedException
+{
+    /**
+     * Creates a new "no state mappings" exception with the given country code.
+     *
+     * @param string $countryCode
+     *
+     * @return NoStateMappingsException
+     */
+    public static function forCountry($countryCode)
+    {
+        return new static(
+            new Phrase(
+                'No state mappings for "%countryCode"',
+                [
+                    'countryCode' => $countryCode,
+                ]
+            )
+        );
+    }
+}


### PR DESCRIPTION
Starting in Magento 2.2, Magento offered supports for Australian states out of the box. Prior to this, installation of first/third party modules was required to add states.

As a result, in Magento 2.1, the latest version of Address Finder would trigger an error if there were no states installed.

Moving forward, **if there are no Australian states installed**, the extension is smart enough to populate the state as a text field instead:

![Screen Shot 2019-12-19 at 12 20 28 pm](https://user-images.githubusercontent.com/181919/71136850-42b85880-225a-11ea-8b14-e054b3a21de2.png)

![Screen Shot 2019-12-19 at 12 20 34 pm](https://user-images.githubusercontent.com/181919/71136881-59f74600-225a-11ea-9d0f-583d4e7858ac.png)
