### PR TITLE
corrected reference to city field

### DIFF
--- a/Observer/FormConfig/AddCheckoutBillingAddress.php
+++ b/Observer/FormConfig/AddCheckoutBillingAddress.php
@@ -124,7 +124,7 @@ class AddCheckoutBillingAddress implements ObserverInterface
                             $code
                         ),
                         'suburb' => sprintf(
-                            'div[name="billingAddress%s.street.2"] input[name="city"]',
+                            'div[name="billingAddress%s.city"] input[name=city]',
                             $code
                         ),
                         'state' => $stateMappings


### PR DESCRIPTION
Small tweak to the form configuration for Australian addresses. The selector for the city field was incorrect, so the Australian suburbs were not populated in the form.