### PR TITLE
Adds the ability for the admin to enable specific forms or all forms without the need to code

### DIFF
--- a/Model/Config/Source/FormsEnabled.php
+++ b/Model/Config/Source/FormsEnabled.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace AddressFinder\AddressFinder\Model\Config\Source;
+
+use AddressFinder\AddressFinder\Observer\FormConfig;
+use Magento\Framework\Data\OptionSourceInterface;
+
+class FormsEnabled implements OptionSourceInterface
+{
+    /**
+     * A constant that represents all forms being enabled.
+     */
+    const ALL = 'all';
+
+    /**
+     * Return array of options as value-label pairs, eg. value => label
+     *
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return [
+            [
+                'label' => __('All'),
+                'value' => self::ALL,
+            ],
+            [
+                'label' => 'Frontend',
+                'value' => [
+                    [
+                        'label' => 'Checkout Billing Address',
+                        'value' => FormConfig\AddCheckoutBillingAddress::FORM_ID,
+                    ],
+                    [
+                        'label' => 'Checkout Shipping Address',
+                        'value' => FormConfig\AddCheckoutShippingAddress::FORM_ID,
+                    ],
+                    [
+                        'label' => 'Customer Address Book',
+                        'value' => FormConfig\AddCustomerAddressBook::FORM_ID,
+                    ],
+                ],
+            ]
+        ];
+    }
+}

--- a/Model/FormConfigProvider.php
+++ b/Model/FormConfigProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace AddressFinder\AddressFinder\Model;
+
+use AddressFinder\AddressFinder\Model\Config\Source\FormsEnabled;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Json\DecoderInterface;
+use Magento\Store\Model\ScopeInterface;
+
+class FormConfigProvider
+{
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * Creates a new form config provider.
+     */
+    public function __construct(ScopeConfigInterface $scopeConfig)
+    {
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * Tells if the given form is enabled or not based on user configuration.
+     *
+     * @param string $form
+     * @return boolTe
+     */
+    public function isFormEnabled(string $form): bool
+    {
+        $config = $this->getConfigValue();
+
+        if (FormsEnabled::ALL === $config) {
+            return true;
+        }
+
+        return in_array($form, $config, true);
+    }
+
+    /**
+     * Gets the configured value, which is either an array of form IDs or a string:
+     *
+     *   FormsEnabled::ALL
+     *
+     * @return array|string
+     *
+     * @see FormsEnabled::toOptionArray()
+     */
+    private function getConfigValue()
+    {
+        /** @var string|null $forms */
+        $forms = $this->scopeConfig->getValue('addressfinder/general/forms_enabled', ScopeInterface::SCOPE_STORE);
+
+        if (empty($forms)) {
+            return FormsEnabled::ALL;
+        }
+
+        $forms = array_map('trim', explode(',', $forms));
+
+        if (in_array(FormsEnabled::ALL, $forms, true)) {
+            return FormsEnabled::ALL;
+        }
+
+        return $forms;
+    }
+}

--- a/Observer/FormConfig/AddCheckoutBillingAddress.php
+++ b/Observer/FormConfig/AddCheckoutBillingAddress.php
@@ -3,6 +3,7 @@
 namespace AddressFinder\AddressFinder\Observer\FormConfig;
 
 use AddressFinder\AddressFinder\Exception\NoStateMappingsException;
+use AddressFinder\AddressFinder\Model\FormConfigProvider;
 use AddressFinder\AddressFinder\Model\StateMappingProvider;
 use Magento\Framework\Data\Collection;
 use Magento\Framework\DataObject;
@@ -15,6 +16,12 @@ use Psr\Log\LoggerInterface;
 
 class AddCheckoutBillingAddress implements ObserverInterface
 {
+    const FORM_ID = 'frontend.checkout.billing.address';
+    /**
+     * @var FormConfigProvider
+     */
+    private $configProvider;
+
     /**
      * @var StateMappingProvider
      */
@@ -33,14 +40,17 @@ class AddCheckoutBillingAddress implements ObserverInterface
     /**
      * Creates a new "Add Checkout Billing Address" observer.
      *
+     * @param FormConfigProvider   $configProvider
      * @param StateMappingProvider $stateMappingProvider
      * @param PaymentHelper        $paymentHelper
      */
     public function __construct(
+        FormConfigProvider $configProvider,
         StateMappingProvider $stateMappingProvider,
         PaymentHelper $paymentHelper,
         LoggerInterface $logger
     ) {
+        $this->configProvider       = $configProvider;
         $this->stateMappingProvider = $stateMappingProvider;
         $this->paymentHelper        = $paymentHelper;
         $this->logger               = $logger;
@@ -51,6 +61,10 @@ class AddCheckoutBillingAddress implements ObserverInterface
      */
     public function execute(Observer $observer)
     {
+        if (!$this->configProvider->isFormEnabled(self::FORM_ID)) {
+            return;
+        }
+
         /** @var Collection $forms */
         $forms = $observer->getEvent()->getData('forms');
 

--- a/Observer/FormConfig/AddCheckoutShippingAddress.php
+++ b/Observer/FormConfig/AddCheckoutShippingAddress.php
@@ -3,6 +3,7 @@
 namespace AddressFinder\AddressFinder\Observer\FormConfig;
 
 use AddressFinder\AddressFinder\Exception\NoStateMappingsException;
+use AddressFinder\AddressFinder\Model\FormConfigProvider;
 use AddressFinder\AddressFinder\Model\StateMappingProvider;
 use Magento\Framework\Data\Collection;
 use Magento\Framework\DataObject;
@@ -13,6 +14,12 @@ use Psr\Log\LoggerInterface;
 
 class AddCheckoutShippingAddress implements ObserverInterface
 {
+    const FORM_ID = 'frontend.checkout.shipping.address';
+    /**
+     * @var FormConfigProvider
+     */
+    private $configProvider;
+
     /**
      * @var StateMappingProvider
      */
@@ -26,10 +33,15 @@ class AddCheckoutShippingAddress implements ObserverInterface
     /**
      * Creates a new "Add Checkout Shipping Address" observer.
      *
+     * @param FormConfigProvider   $configProvider
      * @param StateMappingProvider $stateMappingProvider
      */
-    public function __construct(StateMappingProvider $stateMappingProvider, LoggerInterface $logger)
-    {
+    public function __construct(
+        FormConfigProvider $configProvider,
+        StateMappingProvider $stateMappingProvider,
+        LoggerInterface $logger
+    ) {
+        $this->configProvider       = $configProvider;
         $this->stateMappingProvider = $stateMappingProvider;
         $this->logger               = $logger;
     }
@@ -39,6 +51,10 @@ class AddCheckoutShippingAddress implements ObserverInterface
      */
     public function execute(Observer $observer)
     {
+        if (!$this->configProvider->isFormEnabled(self::FORM_ID)) {
+            return;
+        }
+
         /** @var Collection $forms */
         $forms = $observer->getEvent()->getData('forms');
 

--- a/Observer/FormConfig/AddCustomerAddressBook.php
+++ b/Observer/FormConfig/AddCustomerAddressBook.php
@@ -3,6 +3,7 @@
 namespace AddressFinder\AddressFinder\Observer\FormConfig;
 
 use AddressFinder\AddressFinder\Exception\NoStateMappingsException;
+use AddressFinder\AddressFinder\Model\FormConfigProvider;
 use AddressFinder\AddressFinder\Model\StateMappingProvider;
 use Magento\Framework\Data\Collection;
 use Magento\Framework\DataObject;
@@ -13,6 +14,12 @@ use Psr\Log\LoggerInterface;
 
 class AddCustomerAddressBook implements ObserverInterface
 {
+    const FORM_ID = 'frontend.customer.address.book';
+    /**
+     * @var FormConfigProvider
+     */
+    private $configProvider;
+
     /**
      * @var StateMappingProvider
      */
@@ -28,10 +35,14 @@ class AddCustomerAddressBook implements ObserverInterface
      *
      * @param StateMappingProvider $stateMappingProvider
      */
-    public function __construct(StateMappingProvider $stateMappingProvider, LoggerInterface $logger)
-    {
+    public function __construct(
+        FormConfigProvider $configProvider,
+        StateMappingProvider $stateMappingProvider,
+        LoggerInterface $logger
+    ) {
+        $this->configProvider       = $configProvider;
         $this->stateMappingProvider = $stateMappingProvider;
-        $this->logger = $logger;
+        $this->logger               = $logger;
     }
 
     /**
@@ -39,6 +50,10 @@ class AddCustomerAddressBook implements ObserverInterface
      */
     public function execute(Observer $observer)
     {
+        if (!$this->configProvider->isFormEnabled(self::FORM_ID)) {
+            return;
+        }
+
         /** @var Collection $forms */
         $forms = $observer->getEvent()->getData('forms');
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -23,7 +23,25 @@
           </depends>
         </field>
 
-        <field id="debug_mode" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+        <field id="default_search_country" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+          <label>Default Search Country</label>
+          <source_model>AddressFinder\AddressFinder\Model\Config\Source\DefaultSearchCountry</source_model>
+          <comment>Default country to be searched if your checkout has no country select field.</comment>
+          <depends>
+            <field id="enabled">1</field>
+          </depends>
+        </field>
+
+        <field id="forms_enabled" type="multiselect" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+          <label>Enable Specific Forms</label>
+          <source_model>AddressFinder\AddressFinder\Model\Config\Source\FormsEnabled</source_model>
+          <comment>Enable all forms or specific forms. You may select multiple.</comment>
+          <depends>
+            <field id="enabled">1</field>
+          </depends>
+        </field>
+
+        <field id="debug_mode" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
           <label>Debug Mode</label>
           <source_model>Magento\Config\Model\Config\Source\Enabledisable</source_model>
           <comment>Print debug messages to the Javascript Console.</comment>
@@ -32,18 +50,9 @@
           </depends>
         </field>
 
-        <field id="widget_options" type="textarea" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+        <field id="widget_options" type="textarea" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
           <label>Widget Options</label>
           <comment><![CDATA[Must be in valid JSON format. For a list of options, see our Javascript widget reference for <a href='https://addressfinder.com.au/docs/widget_docs?utm_source=magento&utm_medium=extension&utm_campaign=magento_admin&utm_term=Australia#options'>Australia</a> or <a href='https://addressfinder.nz/docs/widget_docs?utm_source=magento&utm_medium=extension&utm_campaign=magento_admin&utm_term=New%20Zealand#options'>New Zealand</a>.]]></comment>
-          <depends>
-            <field id="enabled">1</field>
-          </depends>
-        </field>
-
-        <field id="default_search_country" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
-          <label>Default Search Country</label>
-          <source_model>AddressFinder\AddressFinder\Model\Config\Source\DefaultSearchCountry</source_model>
-          <comment>Default country to be searched if your checkout has no country select field.</comment>
           <depends>
             <field id="enabled">1</field>
           </depends>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -5,9 +5,10 @@
       <general>
         <enabled>0</enabled>
         <licence_key>ADDRESSFINDER_DEMO_KEY</licence_key>
+        <default_search_country>au</default_search_country>
+        <forms_enabled>all</forms_enabled>
         <debug_mode>0</debug_mode>
         <widget_options>{}</widget_options>
-        <default_search_country>au</default_search_country>
       </general>
     </addressfinder>
   </default>


### PR DESCRIPTION
Currently, to disable forms (such as checkout billing/shipping or customer address book), you need to write a new module and prep up XML code that disables these forms from showing up.

Infrastructure has been added to allow you to choose enabled forms from the admin:

![Screen Shot 2020-02-12 at 10 00 09 pm](https://user-images.githubusercontent.com/181919/74329111-4e9c4300-4de3-11ea-8062-a8e72ef9fe93.png)

This functionality could be expanded out to new forms in the future…

This has been tested in Magento 2.3, I will report back when I have completed testing in older versions. I'd love to hear your thoughts.