### PR TITLE
Fixes state mapping issues and refactors/optimises codebase

### DIFF
--- a/Block/Adminhtml/Plugin.php
+++ b/Block/Adminhtml/Plugin.php
@@ -13,23 +13,16 @@ use Magento\Framework\Json\DecoderInterface;
 
 class Plugin extends Template
 {
+    const FORM_CONFIG_EVENT = 'addressfinder_form_config_admin';
+
     /** @var string */
     protected $_template = 'plugin.phtml';
 
-    /**
-     * @var WidgetConfigProvider
-     */
+    /** @var WidgetConfigProvider */
     private $configProvider;
 
-    /**
-     * @var CollectionFactory
-     */
-    private $collectionFactory;
-
-    /**
-     * @var Collection
-     */
-    private $formsConfig;
+    /** @var FormConfigProvider */
+    private $formConfigProvider;
 
     /**
      * @inheritdoc
@@ -39,14 +32,13 @@ class Plugin extends Template
     public function __construct(
         TemplateContext $context,
         WidgetConfigProvider $configProvider,
-        CollectionFactory $collectionFactory,
+        FormConfigProvider $formConfigProvider,
         array $data = []
-    )
-    {
+    ) {
         parent::__construct($context, $data);
 
         $this->configProvider = $configProvider;
-        $this->collectionFactory = $collectionFactory;
+        $this->formConfigProvider = $formConfigProvider;
     }
 
     /**
@@ -76,23 +68,6 @@ class Plugin extends Template
      */
     public function getFormsConfig()
     {
-        if (null === $this->formsConfig) {
-            /** @var Collection $forms */
-            $this->formsConfig = $this->collectionFactory->create();
-
-            $this->_eventManager->dispatch(
-                'addressfinder_form_config',
-                [
-                    'area' => FormConfigProvider::AREA_ADMIN,
-                    'forms' => $this->formsConfig,
-                ]
-            );
-
-            if (0 === $this->formsConfig->count()) {
-                $this->_logger->warning('There are no configured forms for AddressFinder.');
-            }
-        }
-
-        return $this->formsConfig;
+        return $this->formConfigProvider->get(self::FORM_CONFIG_EVENT);
     }
 }

--- a/Block/Plugin.php
+++ b/Block/Plugin.php
@@ -13,23 +13,16 @@ use Magento\Framework\Json\DecoderInterface;
 
 class Plugin extends Template
 {
+    const FORM_CONFIG_EVENT = 'addressfinder_form_config';
+
     /** @var string */
     protected $_template = 'plugin.phtml';
 
-    /**
-     * @var WidgetConfigProvider
-     */
+    /** @var WidgetConfigProvider */
     private $configProvider;
 
-    /**
-     * @var CollectionFactory
-     */
-    private $collectionFactory;
-
-    /**
-     * @var Collection
-     */
-    private $formsConfig;
+    /** @var FormConfigProvider */
+    private $formConfigProvider;
 
     /**
      * @inheritdoc
@@ -39,14 +32,13 @@ class Plugin extends Template
     public function __construct(
         TemplateContext $context,
         WidgetConfigProvider $configProvider,
-        CollectionFactory $collectionFactory,
+        FormConfigProvider $formConfigProvider,
         array $data = []
-    )
-    {
+    ) {
         parent::__construct($context, $data);
 
         $this->configProvider = $configProvider;
-        $this->collectionFactory = $collectionFactory;
+        $this->formConfigProvider = $formConfigProvider;
     }
 
     /**
@@ -76,23 +68,6 @@ class Plugin extends Template
      */
     public function getFormsConfig()
     {
-        if (null === $this->formsConfig) {
-            /** @var Collection $forms */
-            $this->formsConfig = $this->collectionFactory->create();
-
-            $this->_eventManager->dispatch(
-                'addressfinder_form_config',
-                [
-                    'area' => FormConfigProvider::AREA_FRONTEND,
-                    'forms' => $this->formsConfig,
-                ]
-            );
-
-            if (0 === $this->formsConfig->count()) {
-                $this->_logger->warning('There are no configured forms for AddressFinder.');
-            }
-        }
-
-        return $this->formsConfig;
+        return $this->formConfigProvider->get(self::FORM_CONFIG_EVENT);
     }
 }

--- a/Model/Config/Source/FormsEnabled.php
+++ b/Model/Config/Source/FormsEnabled.php
@@ -4,9 +4,7 @@ namespace AddressFinder\AddressFinder\Model\Config\Source;
 
 use Magento\Framework\Data\Collection;
 use Magento\Framework\Data\CollectionFactory;
-use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Data\OptionSourceInterface;
-use Magento\Framework\DataObject;
 use Magento\Framework\Event\ManagerInterface;
 
 class FormsEnabled implements OptionSourceInterface

--- a/Model/Config/Source/FormsEnabled.php
+++ b/Model/Config/Source/FormsEnabled.php
@@ -6,6 +6,7 @@ use AddressFinder\AddressFinder\Observer\FormConfig\Adminhtml;
 use AddressFinder\AddressFinder\Observer\FormConfig\Frontend;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Data\OptionSourceInterface;
+use Magento\Framework\Event\ManagerInterface;
 
 class FormsEnabled implements OptionSourceInterface
 {
@@ -13,16 +14,6 @@ class FormsEnabled implements OptionSourceInterface
      * A constant that represents all forms being enabled.
      */
     const ALL = 'all';
-
-    /**
-     * @var ProductMetadataInterface
-     */
-    private $productMetadata;
-
-    public function __construct(ProductMetadataInterface $productMetadata)
-    {
-        $this->productMetadata = $productMetadata;
-    }
 
     /**
      * Return array of options as value-label pairs, eg. value => label

--- a/Model/FormConfigProvider.php
+++ b/Model/FormConfigProvider.php
@@ -7,7 +7,6 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Data\Collection;
 use Magento\Framework\Data\CollectionFactory;
 use Magento\Framework\Event\ManagerInterface;
-use Magento\Framework\Json\DecoderInterface;
 use Magento\Store\Model\ScopeInterface;
 use Psr\Log\LoggerInterface;
 
@@ -83,7 +82,7 @@ class FormConfigProvider
     {
         if (!array_key_exists($eventName, $this->formsConfig)) {
 
-            /** @var Collection $forms */
+            /** @var Collection $formsConfig */
             $formsConfig = $this->collectionFactory->create();
 
             $this->events->dispatch(
@@ -125,6 +124,8 @@ class FormConfigProvider
         }
 
         $forms = array_map('trim', explode(',', $forms));
+
+        /** @var array $forms */
 
         if (in_array(FormsEnabled::ALL, $forms, true)) {
             return FormsEnabled::ALL;

--- a/Model/WidgetConfigProvider.php
+++ b/Model/WidgetConfigProvider.php
@@ -90,6 +90,8 @@ class WidgetConfigProvider
         try {
             $decoded = $this->jsonDecoder->decode($json);
         } catch (Zend_Json_Exception $e) {
+            /** @see \Zend_Json::decode() */
+
             $this->logger->warning(
                 sprintf('Failed to decode AddressFinder widget options: "%s"', $e->getMessage()),
                 [

--- a/Observer/Config/Source/Adminhtml/OrderBillingAddress.php
+++ b/Observer/Config/Source/Adminhtml/OrderBillingAddress.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace AddressFinder\AddressFinder\Observer\Config\Source\Adminhtml;
+
+use AddressFinder\AddressFinder\Observer\FormConfig\Adminhtml\AddOrderBillingAddress;
+use Exception;
+use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Framework\Data\Collection;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class OrderBillingAddress implements ObserverInterface
+{
+    const CUTOFF_VERSION = '2.2.0';
+
+    /**
+     * @var ProductMetadataInterface
+     */
+    private $productMetadata;
+
+    public function __construct(ProductMetadataInterface $productMetadata)
+    {
+        $this->productMetadata = $productMetadata;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws Exception
+     */
+    public function execute(Observer $observer)
+    {
+        if (!$this->canUse()) {
+            return;
+        }
+
+        /** @var Collection $adminhtml */
+        $adminhtml = $observer->getEvent()->getData('adminhtml');
+
+        $adminhtml->addItem(new DataObject([
+            'label' => 'Order Billing Address',
+            'value' => AddOrderBillingAddress::FORM_ID,
+        ]));
+    }
+
+    /**
+     * Tells if the form can be used or not.
+     *
+     * @return bool
+     */
+    public function canUse()
+    {
+        return version_compare($this->productMetadata->getVersion(), self::CUTOFF_VERSION, '>=');
+    }
+}

--- a/Observer/Config/Source/Adminhtml/OrderShippingAddress.php
+++ b/Observer/Config/Source/Adminhtml/OrderShippingAddress.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace AddressFinder\AddressFinder\Observer\Config\Source\Adminhtml;
+
+use AddressFinder\AddressFinder\Observer\FormConfig\Adminhtml\AddOrderShippingAddress;
+use Exception;
+use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Framework\Data\Collection;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class OrderShippingAddress implements ObserverInterface
+{
+    const CUTOFF_VERSION = '2.2.0';
+
+    /**
+     * @var ProductMetadataInterface
+     */
+    private $productMetadata;
+
+    public function __construct(ProductMetadataInterface $productMetadata)
+    {
+        $this->productMetadata = $productMetadata;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws Exception
+     */
+    public function execute(Observer $observer)
+    {
+        if (!$this->canUse()) {
+            return;
+        }
+
+        /** @var Collection $adminhtml */
+        $adminhtml = $observer->getEvent()->getData('adminhtml');
+
+        $adminhtml->addItem(new DataObject([
+            'label' => 'Order Shipping Address',
+            'value' => AddOrderShippingAddress::FORM_ID,
+        ]));
+    }
+
+    /**
+     * Tells if the form can be used or not.
+     *
+     * @return bool
+     */
+    public function canUse()
+    {
+        return version_compare($this->productMetadata->getVersion(), self::CUTOFF_VERSION, '>=');
+    }
+}

--- a/Observer/Config/Source/Frontend/CheckoutBillingAddress.php
+++ b/Observer/Config/Source/Frontend/CheckoutBillingAddress.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AddressFinder\AddressFinder\Observer\Config\Source\Frontend;
+
+use AddressFinder\AddressFinder\Observer\FormConfig\Frontend\AddCheckoutBillingAddress;
+use Exception;
+use Magento\Framework\Data\Collection;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class CheckoutBillingAddress implements ObserverInterface
+{
+    /**
+     * @inheritDoc
+     *
+     * @throws Exception
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var Collection $frontend */
+        $frontend = $observer->getEvent()->getData('frontend');
+
+        $frontend->addItem(new DataObject([
+            'label' => 'Checkout Billing Address',
+            'value' => AddCheckoutBillingAddress::FORM_ID,
+        ]));
+    }
+}

--- a/Observer/Config/Source/Frontend/CheckoutShippingAddress.php
+++ b/Observer/Config/Source/Frontend/CheckoutShippingAddress.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AddressFinder\AddressFinder\Observer\Config\Source\Frontend;
+
+use AddressFinder\AddressFinder\Observer\FormConfig\Frontend\AddCheckoutShippingAddress;
+use Exception;
+use Magento\Framework\Data\Collection;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class CheckoutShippingAddress implements ObserverInterface
+{
+    /**
+     * @inheritDoc
+     *
+     * @throws Exception
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var Collection $frontend */
+        $frontend = $observer->getEvent()->getData('frontend');
+
+        $frontend->addItem(new DataObject([
+            'label' => 'Checkout Shipping Address',
+            'value' => AddCheckoutShippingAddress::FORM_ID,
+        ]));
+    }
+}

--- a/Observer/Config/Source/Frontend/CustomerAddressBook.php
+++ b/Observer/Config/Source/Frontend/CustomerAddressBook.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AddressFinder\AddressFinder\Observer\Config\Source\Frontend;
+
+use AddressFinder\AddressFinder\Observer\FormConfig\Frontend\AddCustomerAddressBook;
+use Exception;
+use Magento\Framework\Data\Collection;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class CustomerAddressBook implements ObserverInterface
+{
+    /**
+     * @inheritDoc
+     *
+     * @throws Exception
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var Collection $frontend */
+        $frontend = $observer->getEvent()->getData('frontend');
+
+        $frontend->addItem(new DataObject([
+            'label' => 'Customer Address Book',
+            'value' => AddCustomerAddressBook::FORM_ID,
+        ]));
+    }
+}

--- a/Observer/FormConfig/Adminhtml/AddOrderBillingAddress.php
+++ b/Observer/FormConfig/Adminhtml/AddOrderBillingAddress.php
@@ -3,9 +3,10 @@
 namespace AddressFinder\AddressFinder\Observer\FormConfig\Adminhtml;
 
 use AddressFinder\AddressFinder\Model\FormConfigProvider;
+use AddressFinder\AddressFinder\Model\StateMappingProvider;
+use AddressFinder\AddressFinder\Observer\Config\Source\Adminhtml\OrderBillingAddress;
 use AddressFinder\AddressFinder\Observer\FormConfig\Base;
 use Exception;
-use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Data\Collection;
 use Magento\Framework\DataObject;
 
@@ -13,7 +14,21 @@ class AddOrderBillingAddress extends Base
 {
     const FORM_ID = 'admin.order.billing.address';
 
-    const CUTOFF_VERSION = '2.2.0';
+    /** @var OrderBillingAddress */
+    private $orderBillingAddress;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct(
+        FormConfigProvider $configProvider,
+        StateMappingProvider $stateMappingProvider,
+        OrderBillingAddress $orderBillingAddress
+    ) {
+        parent::__construct($configProvider, $stateMappingProvider);
+
+        $this->orderBillingAddress = $orderBillingAddress;
+    }
 
     /**
      * @inheritDoc
@@ -54,5 +69,11 @@ class AddOrderBillingAddress extends Base
                 'stateMappings' => $this->getStateMappings('AU'),
             ],
         ]));
+    }
+
+    /** {@inheritDoc} */
+    protected function shouldShow()
+    {
+        return parent::shouldShow() && $this->orderBillingAddress->canUse();
     }
 }

--- a/Observer/FormConfig/Adminhtml/AddOrderBillingAddress.php
+++ b/Observer/FormConfig/Adminhtml/AddOrderBillingAddress.php
@@ -2,93 +2,26 @@
 
 namespace AddressFinder\AddressFinder\Observer\FormConfig\Adminhtml;
 
-use AddressFinder\AddressFinder\Exception\NoStateMappingsException;
 use AddressFinder\AddressFinder\Model\FormConfigProvider;
-use AddressFinder\AddressFinder\Model\StateMappingProvider;
+use AddressFinder\AddressFinder\Observer\FormConfig\Base;
+use Exception;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Data\Collection;
 use Magento\Framework\DataObject;
-use Magento\Framework\Event\Observer;
-use Magento\Framework\Event\ObserverInterface;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Psr\Log\LoggerInterface;
 
-class AddOrderBillingAddress implements ObserverInterface
+class AddOrderBillingAddress extends Base
 {
     const FORM_ID = 'admin.order.billing.address';
 
     const CUTOFF_VERSION = '2.2.0';
 
     /**
-     * @var FormConfigProvider
-     */
-    private $configProvider;
-
-    /**
-     * @var StateMappingProvider
-     */
-    private $stateMappingProvider;
-
-    /**
-     * @var ProductMetadataInterface
-     */
-    private $productMetadata;
-
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
-     * Creates a new "Add Checkout Shipping Address" observer.
+     * @inheritDoc
      *
-     * @param FormConfigProvider $configProvider
-     * @param StateMappingProvider $stateMappingProvider
+     * @throws Exception
      */
-    public function __construct(
-        FormConfigProvider $configProvider,
-        StateMappingProvider $stateMappingProvider,
-        ProductMetadataInterface $productMetadata,
-        LoggerInterface $logger
-    ) {
-        $this->configProvider       = $configProvider;
-        $this->stateMappingProvider = $stateMappingProvider;
-        $this->productMetadata      = $productMetadata;
-        $this->logger               = $logger;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function execute(Observer $observer)
+    protected function addForm(Collection $forms)
     {
-        if (version_compare($this->productMetadata->getVersion(), self::CUTOFF_VERSION, '<')) {
-            return;
-        }
-
-        /** @var string $area */
-        $area = $observer->getEvent()->getData('area');
-
-        if (FormConfigProvider::AREA_ADMIN !== $area || !$this->configProvider->isFormEnabled(self::FORM_ID)) {
-            return;
-        }
-
-        /** @var Collection $forms */
-        $forms = $observer->getEvent()->getData('forms');
-
-        try {
-            $stateMappings = $this->stateMappingProvider->forCountry('AU');
-        } catch (NoSuchEntityException $e) {
-            $this->logger->error(sprintf(
-                    'Could not attach order billing address: %s.',
-                    $e->getMessage())
-            );
-
-            return;
-        } catch (NoStateMappingsException $e) {
-            $stateMappings = null;
-        }
-
         $forms->addItem(new DataObject([
             'id' => self::FORM_ID,
             'label' => 'Order Billing Address',
@@ -113,12 +46,12 @@ class AddOrderBillingAddress implements ObserverInterface
                     'address1' => '#order-billing_address_street0',
                     'address2' => '#order-billing_address_street1',
                     'suburb' => '#order-billing_address_city',
-                    'state' => $stateMappings
+                    'state' => $this->getStateMappings('AU')
                         ? '#order-billing_address_region_id'
                         : '#order-billing_address_region',
                     'postcode' => '#order-billing_address_postcode',
                 ],
-                'stateMappings' => $stateMappings,
+                'stateMappings' => $this->getStateMappings('AU'),
             ],
         ]));
     }

--- a/Observer/FormConfig/Adminhtml/AddOrderShippingAddress.php
+++ b/Observer/FormConfig/Adminhtml/AddOrderShippingAddress.php
@@ -3,9 +3,10 @@
 namespace AddressFinder\AddressFinder\Observer\FormConfig\Adminhtml;
 
 use AddressFinder\AddressFinder\Model\FormConfigProvider;
+use AddressFinder\AddressFinder\Model\StateMappingProvider;
+use AddressFinder\AddressFinder\Observer\Config\Source\Adminhtml\OrderShippingAddress;
 use AddressFinder\AddressFinder\Observer\FormConfig\Base;
 use Exception;
-use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Data\Collection;
 use Magento\Framework\DataObject;
 
@@ -13,7 +14,22 @@ class AddOrderShippingAddress extends Base
 {
     const FORM_ID = 'admin.order.shipping.address';
 
-    const CUTOFF_VERSION = '2.2.0';
+    /** @var OrderShippingAddress */
+    private $orderShippingAddress;
+
+    /**
+     * {@inheritDoc}
+     *
+     */
+    public function __construct(
+        FormConfigProvider $configProvider,
+        StateMappingProvider $stateMappingProvider,
+        OrderShippingAddress $orderShippingAddress
+    ) {
+        parent::__construct($configProvider, $stateMappingProvider);
+
+        $this->orderShippingAddress = $orderShippingAddress;
+    }
 
     /**
      * @inheritDoc
@@ -54,5 +70,11 @@ class AddOrderShippingAddress extends Base
                 'stateMappings' => $this->getStateMappings('AU'),
             ],
         ]));
+    }
+
+    /** {@inheritDoc} */
+    protected function shouldShow()
+    {
+        return parent::shouldShow() && $this->orderShippingAddress->canUse();
     }
 }

--- a/Observer/FormConfig/Adminhtml/AddOrderShippingAddress.php
+++ b/Observer/FormConfig/Adminhtml/AddOrderShippingAddress.php
@@ -2,93 +2,26 @@
 
 namespace AddressFinder\AddressFinder\Observer\FormConfig\Adminhtml;
 
-use AddressFinder\AddressFinder\Exception\NoStateMappingsException;
 use AddressFinder\AddressFinder\Model\FormConfigProvider;
-use AddressFinder\AddressFinder\Model\StateMappingProvider;
+use AddressFinder\AddressFinder\Observer\FormConfig\Base;
+use Exception;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Data\Collection;
 use Magento\Framework\DataObject;
-use Magento\Framework\Event\Observer;
-use Magento\Framework\Event\ObserverInterface;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Psr\Log\LoggerInterface;
 
-class AddOrderShippingAddress implements ObserverInterface
+class AddOrderShippingAddress extends Base
 {
     const FORM_ID = 'admin.order.shipping.address';
 
     const CUTOFF_VERSION = '2.2.0';
 
     /**
-     * @var FormConfigProvider
-     */
-    private $configProvider;
-
-    /**
-     * @var StateMappingProvider
-     */
-    private $stateMappingProvider;
-
-    /**
-     * @var ProductMetadataInterface
-     */
-    private $productMetadata;
-
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
-     * Creates a new "Add Checkout Shipping Address" observer.
+     * @inheritDoc
      *
-     * @param FormConfigProvider   $configProvider
-     * @param StateMappingProvider $stateMappingProvider
+     * @throws Exception
      */
-    public function __construct(
-        FormConfigProvider $configProvider,
-        StateMappingProvider $stateMappingProvider,
-        ProductMetadataInterface $productMetadata,
-        LoggerInterface $logger
-    ) {
-        $this->configProvider       = $configProvider;
-        $this->stateMappingProvider = $stateMappingProvider;
-        $this->productMetadata      = $productMetadata;
-        $this->logger               = $logger;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function execute(Observer $observer)
+    protected function addForm(Collection $forms)
     {
-        if (version_compare($this->productMetadata->getVersion(), self::CUTOFF_VERSION, '<')) {
-            return;
-        }
-
-        /** @var string $area */
-        $area = $observer->getEvent()->getData('area');
-
-        if (FormConfigProvider::AREA_ADMIN !== $area || !$this->configProvider->isFormEnabled(self::FORM_ID)) {
-            return;
-        }
-
-        /** @var Collection $forms */
-        $forms = $observer->getEvent()->getData('forms');
-
-        try {
-            $stateMappings = $this->stateMappingProvider->forCountry('AU');
-        } catch (NoSuchEntityException $e) {
-            $this->logger->error(sprintf(
-                    'Could not attach order shipping address: %s.',
-                    $e->getMessage())
-            );
-
-            return;
-        } catch (NoStateMappingsException $e) {
-            $stateMappings = null;
-        }
-
         $forms->addItem(new DataObject([
             'id' => self::FORM_ID,
             'label' => 'Order Shipping Address',
@@ -113,12 +46,12 @@ class AddOrderShippingAddress implements ObserverInterface
                     'address1' => '#order-shipping_address_street0',
                     'address2' => '#order-shipping_address_street1',
                     'suburb' => '#order-shipping_address_city',
-                    'state' => $stateMappings
+                    'state' => $this->getStateMappings('AU')
                         ? '#order-shipping_address_region_id'
                         : '#order-shipping_address_region',
                     'postcode' => '#order-shipping_address_postcode',
                 ],
-                'stateMappings' => $stateMappings,
+                'stateMappings' => $this->getStateMappings('AU'),
             ],
         ]));
     }

--- a/Observer/FormConfig/Base.php
+++ b/Observer/FormConfig/Base.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace AddressFinder\AddressFinder\Observer\FormConfig;
+
+use AddressFinder\AddressFinder\Exception\NoStateMappingsException;
+use AddressFinder\AddressFinder\Model\FormConfigProvider;
+use AddressFinder\AddressFinder\Model\StateMappingProvider;
+use LogicException;
+use Magento\Directory\Api\CountryInformationAcquirerInterface;
+use Magento\Framework\Data\Collection;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+abstract class Base implements ObserverInterface
+{
+    /**
+     * A unique identifier for the form.
+     *
+     * @var string
+     */
+    const FORM_ID = null;
+
+    /**
+     * @var FormConfigProvider
+     */
+    private $configProvider;
+
+    /**
+     * @var StateMappingProvider
+     */
+    private $stateMappingProvider;
+
+    /**
+     * Creates a new observer.
+     *
+     * @param FormConfigProvider $configProvider
+     * @param StateMappingProvider $stateMappingProvider
+     */
+    public function __construct(
+        FormConfigProvider $configProvider,
+        StateMappingProvider $stateMappingProvider
+    ) {
+        $this->configProvider = $configProvider;
+        $this->stateMappingProvider = $stateMappingProvider;
+
+        if (!static::FORM_ID) {
+            throw new LogicException('You must configure the form ID and it must be unique from all other forms.');
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute(Observer $observer)
+    {
+        if (!$this->shouldShow()) {
+            return;
+        }
+
+        /** @var Collection $forms */
+        $forms = $observer->getEvent()->getData('forms');
+
+        $this->addForm($forms);
+    }
+
+    /**
+     * Adds the form to the new forms collection.
+     *
+     * @param Collection $forms
+     *
+     * @return void
+     */
+    abstract protected function addForm(Collection $forms);
+
+    /**
+     * Tells if the form should show or not.
+     */
+    protected function shouldShow()
+    {
+        return $this->configProvider->isFormEnabled(static::FORM_ID);
+    }
+
+    /**
+     * Fetches state mappings for the given country code. If the country is disabled/not installed, or
+     * there are no states installed for that country (e.g. NZ), we'll return null instead.
+     *
+     * @param string $countryCode
+     *
+     * @return array|null
+     *
+     * @see CountryInformationAcquirerInterface::getCountryInfo()
+     */
+    protected function getStateMappings($countryCode)
+    {
+        try {
+            return $this->stateMappingProvider->forCountry($countryCode);
+        } catch (NoSuchEntityException $e) {
+            // The country is disabled/not installed
+        } catch (NoStateMappingsException $e) {
+            // There are no states for the country
+        }
+
+        return null;
+    }
+}

--- a/Observer/FormConfig/Frontend/AddCheckoutShippingAddress.php
+++ b/Observer/FormConfig/Frontend/AddCheckoutShippingAddress.php
@@ -2,79 +2,23 @@
 
 namespace AddressFinder\AddressFinder\Observer\FormConfig\Frontend;
 
-use AddressFinder\AddressFinder\Exception\NoStateMappingsException;
 use AddressFinder\AddressFinder\Model\FormConfigProvider;
-use AddressFinder\AddressFinder\Model\StateMappingProvider;
+use AddressFinder\AddressFinder\Observer\FormConfig\Base;
+use Exception;
 use Magento\Framework\Data\Collection;
 use Magento\Framework\DataObject;
-use Magento\Framework\Event\Observer;
-use Magento\Framework\Event\ObserverInterface;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Psr\Log\LoggerInterface;
 
-class AddCheckoutShippingAddress implements ObserverInterface
+class AddCheckoutShippingAddress extends Base
 {
     const FORM_ID = 'frontend.checkout.shipping.address';
 
     /**
-     * @var FormConfigProvider
-     */
-    private $configProvider;
-
-    /**
-     * @var StateMappingProvider
-     */
-    private $stateMappingProvider;
-
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
-     * Creates a new "Add Checkout Shipping Address" observer.
+     * @inheritDoc
      *
-     * @param FormConfigProvider $configProvider
-     * @param StateMappingProvider $stateMappingProvider
+     * @throws Exception
      */
-    public function __construct(
-        FormConfigProvider $configProvider,
-        StateMappingProvider $stateMappingProvider,
-        LoggerInterface $logger
-    ) {
-        $this->configProvider = $configProvider;
-        $this->stateMappingProvider = $stateMappingProvider;
-        $this->logger = $logger;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function execute(Observer $observer)
+    protected function addForm(Collection $forms)
     {
-        /** @var string $area */
-        $area = $observer->getEvent()->getData('area');
-
-        if (FormConfigProvider::AREA_FRONTEND !== $area || !$this->configProvider->isFormEnabled(self::FORM_ID)) {
-            return;
-        }
-
-        /** @var Collection $forms */
-        $forms = $observer->getEvent()->getData('forms');
-
-        try {
-            $stateMappings = $this->stateMappingProvider->forCountry('AU');
-        } catch (NoSuchEntityException $e) {
-            $this->logger->error(sprintf(
-                    'Could not attach checkout shipping address: %s.',
-                    $e->getMessage())
-            );
-
-            return;
-        } catch (NoStateMappingsException $e) {
-            $stateMappings = null;
-        }
-
         $forms->addItem(new DataObject([
             'id' => self::FORM_ID,
             'label' => 'Checkout Shipping Address',
@@ -99,12 +43,12 @@ class AddCheckoutShippingAddress implements ObserverInterface
                     'address1' => '.form-shipping-address input[name="street[0]"]',
                     'address2' => '.form-shipping-address input[name="street[1]"]',
                     'suburb' => '.form-shipping-address input[name="city"]',
-                    'state' => $stateMappings
+                    'state' => $this->getStateMappings('AU')
                         ? '.form-shipping-address select[name=region_id]'
                         : '.form-shipping-address input[name=region]',
                     'postcode' => '.form-shipping-address input[name=postcode]',
                 ],
-                'stateMappings' => $stateMappings,
+                'stateMappings' => $this->getStateMappings('AU'),
             ],
         ]));
     }

--- a/Observer/FormConfig/Frontend/AddCheckoutShippingAddress.php
+++ b/Observer/FormConfig/Frontend/AddCheckoutShippingAddress.php
@@ -2,7 +2,6 @@
 
 namespace AddressFinder\AddressFinder\Observer\FormConfig\Frontend;
 
-use AddressFinder\AddressFinder\Model\FormConfigProvider;
 use AddressFinder\AddressFinder\Observer\FormConfig\Base;
 use Exception;
 use Magento\Framework\Data\Collection;

--- a/Observer/FormConfig/Frontend/AddCustomerAddressBook.php
+++ b/Observer/FormConfig/Frontend/AddCustomerAddressBook.php
@@ -2,7 +2,6 @@
 
 namespace AddressFinder\AddressFinder\Observer\FormConfig\Frontend;
 
-use AddressFinder\AddressFinder\Model\FormConfigProvider;
 use AddressFinder\AddressFinder\Observer\FormConfig\Base;
 use Exception;
 use Magento\Framework\Data\Collection;

--- a/Observer/FormConfig/Frontend/AddCustomerAddressBook.php
+++ b/Observer/FormConfig/Frontend/AddCustomerAddressBook.php
@@ -2,77 +2,23 @@
 
 namespace AddressFinder\AddressFinder\Observer\FormConfig\Frontend;
 
-use AddressFinder\AddressFinder\Exception\NoStateMappingsException;
 use AddressFinder\AddressFinder\Model\FormConfigProvider;
-use AddressFinder\AddressFinder\Model\StateMappingProvider;
+use AddressFinder\AddressFinder\Observer\FormConfig\Base;
+use Exception;
 use Magento\Framework\Data\Collection;
 use Magento\Framework\DataObject;
-use Magento\Framework\Event\Observer;
-use Magento\Framework\Event\ObserverInterface;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Psr\Log\LoggerInterface;
 
-class AddCustomerAddressBook implements ObserverInterface
+class AddCustomerAddressBook extends Base
 {
     const FORM_ID = 'frontend.customer.address.book';
 
     /**
-     * @var FormConfigProvider
-     */
-    private $configProvider;
-
-    /**
-     * @var StateMappingProvider
-     */
-    private $stateMappingProvider;
-
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
-     * Creates a new "Add Customer Address Book" observer.
+     * @inheritDoc
      *
-     * @param StateMappingProvider $stateMappingProvider
+     * @throws Exception
      */
-    public function __construct(
-        FormConfigProvider $configProvider,
-        StateMappingProvider $stateMappingProvider,
-        LoggerInterface $logger
-    ) {
-        $this->configProvider       = $configProvider;
-        $this->stateMappingProvider = $stateMappingProvider;
-        $this->logger               = $logger;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function execute(Observer $observer)
+    protected function addForm(Collection $forms)
     {
-        /** @var string $area */
-        $area = $observer->getEvent()->getData('area');
-
-        if (FormConfigProvider::AREA_FRONTEND !== $area || !$this->configProvider->isFormEnabled(self::FORM_ID)) {
-            return;
-        }
-
-        /** @var Collection $forms */
-        $forms = $observer->getEvent()->getData('forms');
-
-        try {
-            $stateMappings = $this->stateMappingProvider->forCountry('AU');
-        } catch (NoSuchEntityException $e) {
-            $this->logger->error(sprintf(
-                'Could not attach customer address book: %s.',
-                $e->getMessage())
-            );
-            return;
-        } catch (NoStateMappingsException $e) {
-            $stateMappings = null;
-        }
-
         $forms->addItem(new DataObject([
             'id' => self::FORM_ID,
             'label' => 'Customer Address Book',
@@ -96,12 +42,12 @@ class AddCustomerAddressBook implements ObserverInterface
                     'address1' => 'input#street_1',
                     'address2' => 'input#street_2',
                     'suburb' => 'input[name=city]',
-                    'state' => $stateMappings
+                    'state' => $this->getStateMappings('AU')
                         ? 'select[name=region_id]'
                         : 'input[name=region]',
                     'postcode' => 'input[name=postcode]',
                 ],
-                'stateMappings' => $stateMappings,
+                'stateMappings' => $this->getStateMappings('AU'),
             ],
         ]));
     }

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -2,28 +2,12 @@
 
 namespace AddressFinder\AddressFinder\Setup;
 
-use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\Setup\UpgradeDataInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\UpgradeDataInterface;
 
 class UpgradeData implements UpgradeDataInterface
 {
-    /**
-     * The Scope Config instance.
-     *
-     * @var ScopeConfigInterface
-     */
-    private $scopeConfig;
-
-    /**
-     * Creates a new Upgrade Data instance.
-     */
-    public function __construct(ScopeConfigInterface $scopeConfig)
-    {
-        $this->scopeConfig = $scopeConfig;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -49,7 +33,7 @@ class UpgradeData implements UpgradeDataInterface
     {
         // We'll set the enabled flag based on the existence of a license key,
         // which was the assumed behaviour in the template previously.
-        $hasLicenseKey = !!$setup->getConnection()->fetchOne(
+        $hasLicenseKey = (bool) $setup->getConnection()->fetchOne(
             $setup->getConnection()
                 ->select()
                 ->from($setup->getTable('core_config_data'), 'value')

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -1,13 +1,18 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
-    <event name="addressfinder_form_config">
+
+    <!-- Attach admin forms -->
+    <event name="addressfinder_form_config_admin">
         <observer name="admin_order_billing_address"
                   instance="AddressFinder\AddressFinder\Observer\FormConfig\Adminhtml\AddOrderBillingAddress"/>
 
         <observer name="admin_order_shipping_address"
                   instance="AddressFinder\AddressFinder\Observer\FormConfig\Adminhtml\AddOrderShippingAddress"/>
+    </event>
 
+    <!-- Attach regular forms -->
+    <event name="addressfinder_form_config">
         <observer name="frontend_checkout_billing_address"
                   instance="AddressFinder\AddressFinder\Observer\FormConfig\Frontend\AddCheckoutBillingAddress"/>
 
@@ -17,4 +22,5 @@
         <observer name="frontend_customer_address_book"
                   instance="AddressFinder\AddressFinder\Observer\FormConfig\Frontend\AddCustomerAddressBook"/>
     </event>
+
 </config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -2,6 +2,24 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
 
+    <!-- Attach form selector to admin -->
+    <event name="addressfinder_config_source_forms_enabled">
+        <observer name="admin_order_billing_address"
+                  instance="AddressFinder\AddressFinder\Observer\Config\Source\Adminhtml\OrderBillingAddress"/>
+
+        <observer name="admin_order_shipping_address"
+                  instance="AddressFinder\AddressFinder\Observer\Config\Source\Adminhtml\OrderShippingAddress"/>
+
+        <observer name="frontend_checkout_billing_address"
+                  instance="AddressFinder\AddressFinder\Observer\Config\Source\Frontend\CheckoutBillingAddress"/>
+
+        <observer name="frontend_checkout_shipping_address"
+                  instance="AddressFinder\AddressFinder\Observer\Config\Source\Frontend\CheckoutShippingAddress"/>
+
+        <observer name="frontend_customer_address_book"
+                  instance="AddressFinder\AddressFinder\Observer\Config\Source\Frontend\CustomerAddressBook"/>
+    </event>
+
     <!-- Attach admin forms -->
     <event name="addressfinder_form_config_admin">
         <observer name="admin_order_billing_address"


### PR DESCRIPTION
@LiamKarlMitchell has identified an issue that occurs if you have Australia disabled in Magento. Magento's `CountryInformationAcquirerInterface` will throw an exception if the requested country doesn't exist. In the case of Liam's installation, this was Australia. We were catching this exception and bailing out from adding form config for when Australia was selected as the country.

in search of the architecturally neatest way to pull this off, I went down a rabbit hole of refactoring how form config is produced. Importantly, my refactor remains backwards compatible with the `v1.4.0` release and simplifies the developer experience significantly when adding forms.

I have separated out the event that is fired where form configuration is fetched so that a separate event is fired in the admin. This ensures that only relevant forms are loaded without requiring the convoluted area checks. 

I have also simplified the `Plugin` block (for both admin and frontend) so that complex logic isn't repeated and instead delegated providing form config to the… `FormConfigProvider` class. 🤦‍♂ 

These refactors have resulted in a net reduction in lines of code. 🎉 

**✅  These changes have been tested in Magento 2.1 - 2.3**