### PR TITLE
Disables admin forms in versions of Magento less than 2.2

### DIFF
--- a/Observer/FormConfig/Adminhtml/AddOrderBillingAddress.php
+++ b/Observer/FormConfig/Adminhtml/AddOrderBillingAddress.php
@@ -5,6 +5,7 @@ namespace AddressFinder\AddressFinder\Observer\FormConfig\Adminhtml;
 use AddressFinder\AddressFinder\Exception\NoStateMappingsException;
 use AddressFinder\AddressFinder\Model\FormConfigProvider;
 use AddressFinder\AddressFinder\Model\StateMappingProvider;
+use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Data\Collection;
 use Magento\Framework\DataObject;
 use Magento\Framework\Event\Observer;
@@ -15,6 +16,8 @@ use Psr\Log\LoggerInterface;
 class AddOrderBillingAddress implements ObserverInterface
 {
     const FORM_ID = 'admin.order.billing.address';
+
+    const CUTOFF_VERSION = '2.2.0';
 
     /**
      * @var FormConfigProvider
@@ -27,6 +30,11 @@ class AddOrderBillingAddress implements ObserverInterface
     private $stateMappingProvider;
 
     /**
+     * @var ProductMetadataInterface
+     */
+    private $productMetadata;
+
+    /**
      * @var LoggerInterface
      */
     private $logger;
@@ -34,16 +42,18 @@ class AddOrderBillingAddress implements ObserverInterface
     /**
      * Creates a new "Add Checkout Shipping Address" observer.
      *
-     * @param FormConfigProvider   $configProvider
+     * @param FormConfigProvider $configProvider
      * @param StateMappingProvider $stateMappingProvider
      */
     public function __construct(
         FormConfigProvider $configProvider,
         StateMappingProvider $stateMappingProvider,
+        ProductMetadataInterface $productMetadata,
         LoggerInterface $logger
     ) {
         $this->configProvider       = $configProvider;
         $this->stateMappingProvider = $stateMappingProvider;
+        $this->productMetadata      = $productMetadata;
         $this->logger               = $logger;
     }
 
@@ -52,6 +62,10 @@ class AddOrderBillingAddress implements ObserverInterface
      */
     public function execute(Observer $observer)
     {
+        if (version_compare($this->productMetadata->getVersion(), self::CUTOFF_VERSION, '<')) {
+            return;
+        }
+
         /** @var string $area */
         $area = $observer->getEvent()->getData('area');
 

--- a/Observer/FormConfig/Adminhtml/AddOrderShippingAddress.php
+++ b/Observer/FormConfig/Adminhtml/AddOrderShippingAddress.php
@@ -5,6 +5,7 @@ namespace AddressFinder\AddressFinder\Observer\FormConfig\Adminhtml;
 use AddressFinder\AddressFinder\Exception\NoStateMappingsException;
 use AddressFinder\AddressFinder\Model\FormConfigProvider;
 use AddressFinder\AddressFinder\Model\StateMappingProvider;
+use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Data\Collection;
 use Magento\Framework\DataObject;
 use Magento\Framework\Event\Observer;
@@ -16,6 +17,8 @@ class AddOrderShippingAddress implements ObserverInterface
 {
     const FORM_ID = 'admin.order.shipping.address';
 
+    const CUTOFF_VERSION = '2.2.0';
+
     /**
      * @var FormConfigProvider
      */
@@ -25,6 +28,11 @@ class AddOrderShippingAddress implements ObserverInterface
      * @var StateMappingProvider
      */
     private $stateMappingProvider;
+
+    /**
+     * @var ProductMetadataInterface
+     */
+    private $productMetadata;
 
     /**
      * @var LoggerInterface
@@ -40,10 +48,12 @@ class AddOrderShippingAddress implements ObserverInterface
     public function __construct(
         FormConfigProvider $configProvider,
         StateMappingProvider $stateMappingProvider,
+        ProductMetadataInterface $productMetadata,
         LoggerInterface $logger
     ) {
         $this->configProvider       = $configProvider;
         $this->stateMappingProvider = $stateMappingProvider;
+        $this->productMetadata      = $productMetadata;
         $this->logger               = $logger;
     }
 
@@ -52,6 +62,10 @@ class AddOrderShippingAddress implements ObserverInterface
      */
     public function execute(Observer $observer)
     {
+        if (version_compare($this->productMetadata->getVersion(), self::CUTOFF_VERSION, '<')) {
+            return;
+        }
+
         /** @var string $area */
         $area = $observer->getEvent()->getData('area');
 


### PR DESCRIPTION
There's an issue in Magento 2.1 and below where the AddressFinder JS competes with Magento's KnockoutJS where AF attempts to perform work when the DOM changes and Magento attempts to sync shipping/billing addresses when the DOM changes. 

This behaviour doesn't seem to affect versions greater than Magento 2.2.